### PR TITLE
Translation term separation

### DIFF
--- a/artofillusion/polymesh/MeshUnfolder.java
+++ b/artofillusion/polymesh/MeshUnfolder.java
@@ -1,5 +1,7 @@
 /*
  *  Copyright (C) 2007 by Francois Guillet
+ *  Modifications Copyright (C) 2020 Py Petri Ihalainen
+ *
  *  This program is free software; you can redistribute it and/or modify it under the
  *  terms of the GNU General Public License as published by the Free Software
  *  Foundation; either version 2 of the License, or (at your option) any later version.
@@ -561,7 +563,7 @@ public class MeshUnfolder {
 		unfoldedMeshes = new UnfoldedMesh[unfoldedMeshesList.size()];
 		for (int i = 0; i < unfoldedMeshes.length; i++) {
 			unfoldedMeshes[i] = unfoldedMeshesList.get(i);
-			unfoldedMeshes[i].setName(Translate.text("polymesh:piece" + (i + 1)));
+			unfoldedMeshes[i].setName(Translate.text("polymesh:pieceDefaultName") + " " + (i + 1));
 		}
 		return true;
 	}
@@ -925,7 +927,7 @@ public class MeshUnfolder {
 		unfoldedMeshes = new UnfoldedMesh[unfoldedMeshesList.size()];
 		for (int i = 0; i < unfoldedMeshes.length; i++) {
 			unfoldedMeshes[i] = unfoldedMeshesList.get(i);
-			unfoldedMeshes[i].setName(Translate.text("polymesh:piece" + (i + 1)));
+			unfoldedMeshes[i].setName(Translate.text("polymesh:pieceDefaultName") + " " + (i + 1));
 		}
 		return true;
 	}

--- a/artofillusion/polymesh/UVMappingEditorDialog.java
+++ b/artofillusion/polymesh/UVMappingEditorDialog.java
@@ -691,7 +691,7 @@ public class UVMappingEditorDialog extends BDialog {
         BStandardDialog dlg = new BStandardDialog(Translate.text("polymesh:addMapping"), 
                                                   Translate.text("polymesh:enterMappingName"), 
                                                   BStandardDialog.QUESTION);
-        String res = dlg.showInputDialog(this, null, Translate.text("polymesh:mapping") + " #" + (mappingData.mappings.size() + 1));
+        String res = dlg.showInputDialog(this, null, Translate.text("polymesh:mappingDefaultName") + " #" + (mappingCB.getItemCount()+1));
         if (res != null) {
             UVMeshMapping mapping = null;
             if (duplicate)

--- a/polymesh.properties
+++ b/polymesh.properties
@@ -372,11 +372,12 @@ mappingSizeWarning=Some vertex coordinates are outside the texture image area.
 revert=Revert
 fileExtensionChanged=The file was saved as 
 
-# pieces
+# pieces and mappings
 pieceName=Mesh Piece Name
+pieceDefaultName=Piece
 enterPieceName=Enter new piece name:
+mappingDefaultName=Mapping
 enterMappingName=Enter new mapping name:
-# 'mapping' is translated twice -- needs to be separated somehow
-mapping=Mapping
+
 setUndoLevelsTitle=Undo Levels
 numberOfUndoLevels=Number of Undo Levels

--- a/polymesh_de.properties
+++ b/polymesh_de.properties
@@ -365,13 +365,15 @@ chooseExportImageFile=Wählen Sie eine PNG-Datei
 #useBlack=Black
 #exportImage=Export
 #mappingSizeWarning=Some vertex coordinates are \n outside the texture image area.
+#revert=Revert
 #fileExtensionChanged=The file was saved as 
 
-# pieces
+# pieces and mappings
 pieceName=Name des Meshteilstücks
+# pieceDefaultName=Piece
 enterPieceName=Namen eingeben:
+mappingDefaultName=Mapping
 enterMappingName=Neuen Namen für das Mapping eingeben:
-# 'mapping' is translated twice -- needs to be separated somehow
-mapping=Mapping
+
 setUndoLevelsTitle=Rückschritte
 numberOfUndoLevels=Anzahl der Rückschritte

--- a/polymesh_es.properties
+++ b/polymesh_es.properties
@@ -368,11 +368,12 @@ chooseExportImageFile=Elegir archivo PNG
 #revert=Revert
 #fileExtensionChanged=The file was saved as 
 
-# pieces
+# pieces and mappings
 pieceName=Nombre de la Pieza de Malla
+# pieceDefaultName=Piece
 enterPieceName=Introduzca el Nuevo Nombre para Pieza de Malla:
 enterMappingName=Introduzca Nuevo Nombre del Mapeo:
-# 'mapping' is translated twice -- needs to be separated somehow
-mapping=Mapeado
+mappingDefaultName=Mapeado
+
 setUndoLevelsTitle=Deshacer Niveles
 numberOfUndoLevels=Número de Niveles de Deshacer

--- a/polymesh_fi.properties
+++ b/polymesh_fi.properties
@@ -372,11 +372,12 @@ mappingSizeWarning=Koordinaatteja j‰‰ kuvan ulkopuolelle.
 revert=Palaa
 fileExtensionChanged=Tiedosto tallennettiin nimell‰,
 
-# pieces
+# pieces and mappings
 pieceName=Verkon palan nimi
+pieceDefaultName=Pala
 enterPieceName=Anna palan uusi nimi:
+mappingDefaultName=Kartta
 enterMappingName=Anna kartan uusi nimi:
-# 'mapping' is translated twice -- needs to be separated somehow
-mapping=Kartta
+
 setUndoLevelsTitle=Kumoustasot
 numberOfUndoLevels=Kumoustasojen m‰‰r‰

--- a/polymesh_fr.properties
+++ b/polymesh_fr.properties
@@ -372,11 +372,12 @@ chooseExportImageFile=Choisissez un fichier PNG
 #revert=Revert
 #fileExtensionChanged=The file was saved as 
 
-# pieces
+# pieces and mappings
 pieceName=Nom de la pièce
+# pieceDefaultName=Piece
 enterPieceName=Entrez un nouveau nom de pièce :
+mappingDefaultName=Cartographie
 enterMappingName=Entrez un nom pour la cartographie :
-# 'mapping' is translated twice -- needs to be separated somehow
-mapping=Cartographie
+
 setUndoLevelsTitle=Niveaux d'annulation :
 numberOfUndoLevels=Nombre de niveaux d'annulation


### PR DESCRIPTION
...and one other related related fix.

**REWRITE &rarr;**
So basically I:
- Separated the term 'mapping' from the default name of a mapping
- Renamed the variable for the default name of a piece with the same logic 
- Fixed a parenthesis bug in the piece naming. Now pieces actually get the intended names instead of `polymesh:piece`.
- Changed the way the number part of an added mapping was created. (Not sure any more what was happening with it. The old code looks right, but to me it was printing a wrong number on the name. ??)
