### PR TITLE
Clean Command interface code

### DIFF
--- a/src/artofillusion/polymesh/Command.java
+++ b/src/artofillusion/polymesh/Command.java
@@ -1,5 +1,6 @@
 /*
  *  Copyright (C) 2007 by Francois Guillet
+ *  Changes copyright (C) 2022 by Maksim Khramov
  *  This program is free software; you can redistribute it and/or modify it under the
  *  terms of the GNU General Public License as published by the Free Software
  *  Foundation; either version 2 of the License, or (at your option) any later version.
@@ -22,7 +23,9 @@ public interface Command {
      * execute the command
      *
      */
-    public void execute();
+    public default void execute() {
+      redo();
+    }
     
     /**
      * Undo the command

--- a/src/artofillusion/polymesh/UVMappingCanvas.java
+++ b/src/artofillusion/polymesh/UVMappingCanvas.java
@@ -1,6 +1,7 @@
 /*
  *  Copyright (C) 2007 by François Guillet
  *  Modifications Copyright (C) 2019 by Petri Ihalainen
+ *  Changes copyright (C) 2022 by Maksim Khramov
  *
  *  This program is free software; you can redistribute it and/or modify it under the 
  *  terms of the GNU General Public License as published by the Free Software 
@@ -12,7 +13,6 @@
 
 package artofillusion.polymesh;
 
-import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Cursor;
 import java.awt.Dimension;
@@ -28,11 +28,9 @@ import java.awt.BasicStroke;
 import artofillusion.TextureParameter;
 import artofillusion.math.BoundingBox;
 import artofillusion.math.Vec2;
-import artofillusion.math.Vec3;
 import artofillusion.object.FacetedMesh;
 import artofillusion.object.Mesh;
 import artofillusion.object.MeshVertex;
-import artofillusion.object.TriangleMesh;
 import artofillusion.polymesh.UVMappingData.UVMeshMapping;
 import artofillusion.polymesh.UnfoldedMesh.UnfoldedEdge;
 import artofillusion.polymesh.UnfoldedMesh.UnfoldedFace;
@@ -1159,7 +1157,6 @@ public class UVMappingCanvas extends CustomWidget {
         }
 
         public MappingPositionsCommand(Vec2[][] oldPos, Vec2[][] newPos) {
-            super();
             this.oldPos = oldPos;
             this.newPos = newPos;
         }
@@ -1216,10 +1213,7 @@ public class UVMappingCanvas extends CustomWidget {
             }
         }
 
-        public void execute() {
-            redo();
-        }
-
+        @Override
         public void redo() {
             for (int i = 0; i < mapping.v.length; i++)
                 for (int j = 0; j < mapping.v[i].length; j++)
@@ -1230,6 +1224,7 @@ public class UVMappingCanvas extends CustomWidget {
             repaint();
         }
 
+        @Override
         public void undo() {
             for (int i = 0; i < mapping.v.length; i++)
                 for (int j = 0; j < mapping.v[i].length; j++)
@@ -1248,14 +1243,10 @@ public class UVMappingCanvas extends CustomWidget {
         public int[] selection;
 
         public PinCommand(int[] selection) {
-            super();
             this.selection = selection;
         }
 
-        public void execute() {
-            redo();
-        }
-
+        @Override
         public void redo() {
             for (int i = 0; i < selection.length; i++) {
                 mappingData.meshes[currentPiece].vertices[mappingData.verticesTable[currentPiece][selection[i]]].pinned = 
@@ -1264,6 +1255,7 @@ public class UVMappingCanvas extends CustomWidget {
             repaint();
         }
 
+        @Override
         public void undo() {
             redo();
         }
@@ -1281,10 +1273,7 @@ public class UVMappingCanvas extends CustomWidget {
             this.selection = selection;
         }
 
-        public void execute() {
-            redo();
-        }
-
+        @Override
         public void redo() {
             for (int i = 0; i < selection.length; i++)
                 selected[selection[i]] = !selected[selection[i]];
@@ -1292,6 +1281,7 @@ public class UVMappingCanvas extends CustomWidget {
             repaint();
         }
 
+        @Override
         public void undo() {
             redo();
         }
@@ -1323,7 +1313,6 @@ public class UVMappingCanvas extends CustomWidget {
                                           Vec2[] redoPositions, 
                                           UVMeshMapping mapping, 
                                           int piece) {
-            super();
             this.vertIndices = vertIndexes;
             this.undoPositions = undoPositions;
             this.redoPositions = redoPositions;
@@ -1331,10 +1320,7 @@ public class UVMappingCanvas extends CustomWidget {
             this.piece = piece;
         }
 
-        public void execute() {
-            redo();
-        }
-
+        @Override
         public void redo() {
             Vec2[] v = mapping.v[piece];
             for (int i = 0; i < vertIndices.length; i++)
@@ -1344,6 +1330,7 @@ public class UVMappingCanvas extends CustomWidget {
             repaint();
         }
 
+        @Override
         public void undo() {
             Vec2[] v = mapping.v[piece];
             for (int i = 0; i < vertIndices.length; i++)

--- a/src/artofillusion/polymesh/UVMappingEditorDialog.java
+++ b/src/artofillusion/polymesh/UVMappingEditorDialog.java
@@ -1,6 +1,7 @@
 /*
  *  Copyright (C) 2007 by François Guillet
  *  Modifications Copyright (C) 2019 by Petri Ihalainen
+ *  Changes copyright (C) 2022 by Maksim Khramov
  *
  *  This program is free software; you can redistribute it and/or modify it under the 
  *  terms of the GNU General Public License as published by the Free Software 
@@ -15,7 +16,6 @@ package artofillusion.polymesh;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Insets;
-import java.awt.Window;
 import java.awt.Color;
 import java.awt.Image;
 import java.awt.image.BufferedImage;
@@ -25,11 +25,8 @@ import java.awt.geom.Line2D;
 import java.awt.BasicStroke;
 import java.awt.Rectangle;
 
-import java.io.BufferedOutputStream;
-import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.text.DecimalFormat;
@@ -1065,20 +1062,18 @@ public class UVMappingEditorDialog extends BDialog {
         int oldTexture, newTexture;
 
         public ChangeTextureCommand(int oldTexture, int newTexture) {
-            super();
             this.oldTexture = oldTexture;
             this.newTexture = newTexture;
         }
 
-        public void execute() {
-            redo();
-        }
 
+        @Override
         public void redo() {
             textureCB.setSelectedIndex(newTexture);
             doTextureChanged();
         }
 
+        @Override
         public void undo() {
             textureCB.setSelectedIndex(oldTexture);
             doTextureChanged();
@@ -1099,14 +1094,12 @@ public class UVMappingEditorDialog extends BDialog {
             this.newMapping = newMapping;
         }
 
-        public void execute() {
-            redo();
-        }
-
+        @Override
         public void redo() {
             sendToMapping(oldMapping, newMapping);
         }
 
+        @Override
         public void undo() {
             sendToMapping(newMapping, oldMapping);
         }
@@ -1142,14 +1135,13 @@ public class UVMappingEditorDialog extends BDialog {
             this.newMapping = newMapping;
         }
 
-        public void execute() {
-            redo();
-        }
 
+        @Override
         public void redo() {
             changeMapping(newMapping);
         }
 
+        @Override
         public void undo() {
             changeMapping(oldMapping);
         }
@@ -1164,15 +1156,11 @@ public class UVMappingEditorDialog extends BDialog {
         int index;
 
         public RemoveMappingCommand(UVMeshMapping mapping, int index) {
-            super();
             this.mapping = mapping.duplicate();
             this.index = index;
         }
 
-        public void execute() {
-            redo();
-        }
-
+        @Override
         public void redo() 
         {
             ArrayList<UVMeshMapping> mappings = mappingData.getMappings();
@@ -1198,6 +1186,7 @@ public class UVMappingEditorDialog extends BDialog {
             mappingCanvas.repaint();
         }
 
+        @Override
         public void undo() {
             ArrayList<UVMeshMapping> mappings = mappingData.getMappings();
             UVMeshMapping newMapping = mapping.duplicate();
@@ -1233,15 +1222,11 @@ public class UVMappingEditorDialog extends BDialog {
         int selected;
 
         public AddMappingCommand(UVMeshMapping mapping, int selected){
-            super();
             this.mapping = mapping.duplicate();
             this.selected = selected;
         }
 
-        public void execute() {
-            redo();
-        }
-
+        @Override
         public void redo() {
             UVMeshMapping newMapping = mapping.duplicate();
             mappingData.mappings.add(newMapping);
@@ -1255,6 +1240,7 @@ public class UVMappingEditorDialog extends BDialog {
             updateState();
         }
 
+        @Override
         public void undo() {
             ArrayList<UVMeshMapping> mappings = mappingData.getMappings();
             int index = mappings.size() - 1;
@@ -1277,21 +1263,18 @@ public class UVMappingEditorDialog extends BDialog {
         private int newPiece;
 
         public SelectPieceCommand(int oldPiece, int newPiece) {
-            super();
             this.oldPiece = oldPiece;
             this.newPiece = newPiece;
         }
 
-        public void execute() {
-            redo();
-        }
-
+        @Override
         public void redo() {
             mappingCanvas.setSelectedPiece(newPiece);
             pieceList.setSelected(newPiece, true);
             repaint();
         }
 
+        @Override
         public void undo() {
             mappingCanvas.setSelectedPiece(oldPiece);
             pieceList.setSelected(oldPiece, true);
@@ -1309,21 +1292,19 @@ public class UVMappingEditorDialog extends BDialog {
         private String newName;
 
         public RenamePieceCommand(int piece, String oldName, String newName) {
-            super();
             this.piece = piece;
             this.oldName = oldName;
             this.newName = newName;
         }
 
-        public void execute() {
-            redo();
-        }
 
+        @Override
         public void redo() {
             setPieceName(piece, newName);
             repaint();
         }
 
+        @Override
         public void undo() {
             setPieceName(piece, oldName);
         }


### PR DESCRIPTION
Small Command interface usages clean.
default code for execute() method
useless super() calls removed
mark code with Override annotations